### PR TITLE
RegexUtil.js: Fix for CMv4 (Brackets Sprint 38+)

### DIFF
--- a/RegexUtil.js
+++ b/RegexUtil.js
@@ -22,7 +22,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, regexp: true */
-/*global define, brackets, CodeMirror */
+/*global define, brackets */
 
 /**
  * Utilities for working with regular expressions and their matches
@@ -31,8 +31,8 @@ define(function (require, exports, module) {
     "use strict";
     
     // Our own modules
-    var mode                    = require("regex-mode").mode;
-    
+    var mode                    = require("regex-mode").mode,
+        CodeMirror              = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror");
     
     /**
      * Run our tokenizer over the regex and return an array of informal "token" objects


### PR DESCRIPTION
Guess you just missed this file

https://github.com/adobe/brackets/wiki/Brackets-CodeMirror-v4-Migration-Guide

> CodeMirror is no longer global. In Brackets, we used to provide CodeMirror as a global. CodeMirror now supports require(), so we now include CodeMirror as a module instead. This means you should add var CodeMirror = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"); at the top of any module that accesses the CodeMirror object. Sprint 38 will still provide the global CodeMirror (which is the same as the module-loaded CodeMirror), but access to it is deprecated and it will be removed in a future release. (Note that this doesn't affect accesses to editor._codeMirror, which should work as before.)
