### PR TITLE
Add some dark theme tweaks and small html fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
                     groups += "<span class='regex-group-match unmatched-group' data-groupnum='" + i + "'><strong>$" + i + "</strong></span>";
                 }
             }
-            this.$htmlContent.find(".inline-regex-groups").html(groups).show();
+            this.$htmlContent.find(".inline-regex-groups").html(groups).css("display", "inline").show();
         } else {
             this.$htmlContent.find(".inline-regex-groups").hide();
         }

--- a/regex-editor-styles.css
+++ b/regex-editor-styles.css
@@ -75,6 +75,10 @@
     color: #000090
 }
 
+.dark .inline-regex-editor .inline-regex-match {
+    color: #33ccff;
+}
+
 .inline-regex-editor .inline-regex-groups {
     margin-left: 5px;
     background-color: #d3d3ff;
@@ -84,6 +88,10 @@
     font-size: inherit;
     color: #000090;
 }
+.dark .inline-regex-editor .inline-regex-groups {
+    background-color: #000033;
+    color: #33ccff;
+}
 .inline-regex-editor .inline-regex-groups .regex-group-match {
     padding: 0 5px;
 }
@@ -92,6 +100,9 @@
 }
 .inline-regex-editor .inline-regex-groups .regex-group-match:hover {
     background-color: #9f9ff5;
+}
+.dark .inline-regex-editor .inline-regex-groups .regex-group-match:hover {
+    background-color: #000066;
 }
 .inline-regex-editor .inline-regex-groups .regex-group-match strong {
     font-weight: bold;

--- a/regex-editor-styles.css
+++ b/regex-editor-styles.css
@@ -63,7 +63,7 @@
 
 .inline-regex-editor .inline-regex-sample {
     font-family: "SourceCodePro";
-    font-size: inherit;
+    font-size: 12px;
     padding: 2px 2px 2px 6px; /* 6px aligns L edge of text with CM field above */
 }
 


### PR DESCRIPTION
@peterflynn I am not sure if I chose colors that suit you, but I did make it so that the matches and matched groups show up ok on a dark theme.

When I was looking at the styles I noticed that the resulting HTML when you did `.show` on `inline-regex-groups` ended with an orphaned `style>` so I just added `.css()` to explicitly change the style to `display: inline` to avoid the orphaned tag.  Not a big deal since it worked fine before ;)

Great extension, btw!
